### PR TITLE
Update releases.cfg

### DIFF
--- a/releases.cfg
+++ b/releases.cfg
@@ -6,6 +6,11 @@ Sources
 }
 Releases
 {
+  v1r3p16
+  {
+    Modules = GlastDIRAC
+    Depends = DIRAC:v6r12p5
+  }
   v1r3p15
   {
   	Modules = GlastDIRAC


### PR DESCRIPTION
Make GlastDIRAC compatible with the latest DIRAC release (v6r12p5)
