### PR TITLE
catch weird KeyError, LPG-39

### DIFF
--- a/PipelineSystem/Interface/GridAccess.py
+++ b/PipelineSystem/Interface/GridAccess.py
@@ -270,8 +270,10 @@ def removeOutputData(baseDir,logLevel="INFO"):
 
     # ######################################################################################################## #
     rm = ReplicaManager()
-    
-    result = rm.cleanLogicalDirectory(baseDir);
+    try:
+        result = rm.cleanLogicalDirectory(baseDir);
+    except KeyError,ke:
+        return {"OK":False,"Message":"Caught key error, full stacktrace below\n%s"%str(ke),"RC":137}
     print "Ignore the message about the file '"+baseDir+"dirac_directory'"
     if not result['OK']:
         print 'ERROR: %s' % (result['Message'] )


### PR DESCRIPTION
This is to partially address LPG-39 https://jira.slac.stanford.edu/browse/LPG-39 and to catch the root cause by encapsulating the call in a  Try & Raise block. If cleanLogicalDirectory throws this error, it _will_ return IS_OK=False, i.e. the job will be botched. 
